### PR TITLE
New recipe with Vial data

### DIFF
--- a/mts/recipe.json
+++ b/mts/recipe.json
@@ -18,6 +18,11 @@
           ]
         }
       }
+    },
+    "vial": {
+      "source": "mapbox://tileset-source/calltheshots/vial",
+      "minzoom": 2,
+      "maxzoom": 15
     }
   }
 }


### PR DESCRIPTION
This PR adds the `vial` source to the tiles recipe.

Eventually we'll want to go ahead and remove the `jesse` source all together, but we can leave it for now.

Link to Deploy Preview: https://deploy-preview-NNN--beta-vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

#### Site
- [x] I solemnly swear that I QA'd my change. My change does not break the site on localhost nor staging.
