### PR TITLE
style(editorconfig): ✍️ default style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Javascript
+[*.{js,ts,tsx}]
+indent_style = space
+indent_size = 2
+
+# Shell
+[*.sh]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+# Markdown
+[*.{md,txt}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Add `.editorconfig` based on stylistic decisions made in either
`CAVaccineInventory/site` or `CAVaccineInventory/vaccine-feed-ingest`.
