### PR TITLE
Add Special Thanks section to About Us

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -45,6 +45,8 @@ faq_accurate: Is the information on this website accurate?
 faq_accurate_answer: |
     <p class="mb-2">We publish only what the vaccine site told us when we called. The situation is complex, supplies may vary throughout the day, and not everyone at the site might have up-to-the-minute information as to what their policies actually are.</p>
     <p>We’re doing our best, but can’t make any guarantees.</p>
+faq_special_thanks: Special Thanks
+faq_special_thanks_mapbox: Maps sponsored by the <a href="https://www.mapbox.com/community/">Mapbox Community Team</a>.
 zip_error: Failed to locate your zip code, please try again
 english: English
 spanish: Spanish

--- a/about-us.html
+++ b/about-us.html
@@ -49,3 +49,10 @@ content_header: true
   </h3>
   {% t faq_accurate_answer %}
 <div class="mb-5"></div>
+
+<h3 class="mt-5 text-lg font-bold mb-2 bg-yellow-300 px-1 py-1">
+  {% t faq_special_thanks %}
+</h3>
+<div class="mb-5">
+  {% t faq_special_thanks_mapbox %}
+</div>


### PR DESCRIPTION
This PR adds a special thanks section to the about us page that gives a shoutout to Mapbox for the mapping we've got going.

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-79--beta-vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

### Site
- [x] I solemnly swear that I QA'd my change. My change does not break the site on localhost nor staging.

#### Near Me
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
