### PR TITLE
Update MTS recipe for less zoom

### DIFF
--- a/mts/recipe.json
+++ b/mts/recipe.json
@@ -4,7 +4,7 @@
     "vial": {
       "source": "mapbox://tileset-source/calltheshots/vial",
       "minzoom": 2,
-      "maxzoom": 15
+      "maxzoom": 10
     }
   }
 }


### PR DESCRIPTION
Mapbox says we don't need the zoom level we had, so I dropped us down to what they recommended.