### PR TITLE
Sort sites based on distance from center of map

### DIFF
--- a/webpack/near-me.js
+++ b/webpack/near-me.js
@@ -114,18 +114,22 @@ const renderCardsFromMap = () => {
     initMap();
   }
 
-  toggleVisibility(loadingSpinnerElem, false);
-
-  // Eventually, we'll want some smarter sorting of what we show, but for now
-  // lets grab 10 unique things off the map
   const features = getUniqueFeatures(
     map.queryRenderedFeatures({ layers: [featureLayer] })
-  ).slice(0, 10);
+  ).map((feature) => {
+    const ll = new mapboxgl.LngLat(...feature.geometry.coordinates);
+    feature["distance"] = ll.distanceTo(map.getCenter());
+    return feature;
+  });
+
+  features.sort((a, b) => a.distance - b.distance);
+
+  toggleVisibility(loadingSpinnerElem, false);
 
   const cards = document.getElementById("cards");
   cards.innerHTML = "";
 
-  features.forEach((feature) => {
+  features.slice(0, 10).forEach((feature) => {
     const properties = feature.properties;
     const gmapsLink = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
       properties.address


### PR DESCRIPTION
This PR adjusts the near me site sorting by actually showing sites starting with those closest to the center of the map.

Closes https://github.com/CAVaccineInventory/vaccinatethestates/issues/71

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-87--beta-vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

### Site
- [x] I solemnly swear that I QA'd my change. My change does not break the site on localhost nor staging.

#### Near Me
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
