### PR TITLE
Add a bounding box for our MTS Recipe

### DIFF
--- a/mts/recipe.json
+++ b/mts/recipe.json
@@ -4,7 +4,10 @@
     "vial": {
       "source": "mapbox://tileset-source/calltheshots/vial",
       "minzoom": 2,
-      "maxzoom": 10
+      "maxzoom": 10,
+      "features": {
+        "bbox": [-179.149, -14.549, 179.779, 71.367]
+      }
     }
   }
 }


### PR DESCRIPTION
Mapbox suggested we use a bounding box to generate some less tiles. That seems like a good idea!

I derived this bounding box via https://gist.github.com/a8dx/2340f9527af64f8ef8439366de981168

I've also updated the recipe on MTS, but did not publish new tiles. I figure that can happen when we do it normally.

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-97--beta-vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

### Site
- [x] I solemnly swear that I QA'd my change. My change does not break the site on localhost nor staging.

#### Near Me
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
