### PR TITLE
Allow multiple cards to be open

### DIFF
--- a/webpack/near-me.js
+++ b/webpack/near-me.js
@@ -146,20 +146,6 @@ const renderCardsFromMap = () => {
 
     cards.appendChild(range);
   });
-
-  // Ensure only one card can be open at a time
-  // From https://stackoverflow.com/questions/16751345/automatically-close-all-the-other-details-tags-after-opening-a-specific-detai
-  const details = document.querySelectorAll("details");
-
-  details.forEach((targetDetail) => {
-    targetDetail.addEventListener("click", () => {
-      details.forEach((detail) => {
-        if (detail !== targetDetail) {
-          detail.removeAttribute("open");
-        }
-      });
-    });
-  });
 };
 
 const getUniqueFeatures = (array) => {


### PR DESCRIPTION
From https://github.com/CAVaccineInventory/vaccinatethestates/issues/114


Link to Deploy Preview: https://deploy-preview-115--beta-vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

### Site
- [x] I solemnly swear that I QA'd my change. My change does not break the site on localhost nor staging.

#### Near Me
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
