### PR TITLE
Update netlify URLs in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
     Replace the NNN in the URL below with the ID of this Pull Request.
     That's the URL where Netlify will automatically deploy a staging build.
 -->
-Link to Deploy Preview: https://deploy-preview-NNN--beta-vaccinatethestates.netlify.app/
+Link to Deploy Preview: https://deploy-preview-NNN--vaccinatethestates.netlify.app/
 
 ---
 


### PR DESCRIPTION
We're now just `vaccinatethestates`, so lets update the netlify URL in the template!

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-145--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### About Us
- [x] Organizers show up and randomize on page load
