### PR TITLE
Stack `Something Look Wrong` text in smaller sizes

### DIFF
--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -67,11 +67,11 @@
                     <p>
                         {{t "data_from"}}
                         <a href="https://vaccinefinder.org" target="_blank">
-                        <img
-                        class="inline object-contain"
-                        width="100"
-                        src="/assets/img/vaccinefinder_logo.png"
-                        />
+                            <img
+                                alt="VaccineFinder"
+                                class="inline h-3"
+                                src="/assets/img/vaccinefinder_logo.png"
+                            />
                         </a>
                     </p>
                 {{/if}}


### PR DESCRIPTION
@obra pointed out that this kinda looks weird:
![](https://cdn.discordapp.com/attachments/799197521540022292/835313702667943986/unknown.png)

This PR makes it look like this:
<img width="426" alt="Screen Shot 2021-04-23 at 5 53 17 🌃" src="https://user-images.githubusercontent.com/2546/115942263-394a8c00-a45e-11eb-840b-2684ba5d0dd4.png">

Unless there's space at which point it looks like this:
<img width="540" alt="Screen Shot 2021-04-23 at 5 53 08 🌃" src="https://user-images.githubusercontent.com/2546/115942271-410a3080-a45e-11eb-90bc-fac37eab4779.png">


<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-146--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### About Us
- [x] Organizers show up and randomize on page load
