### PR TITLE
Center VaccineFinder logo in card footer

### DIFF
--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -69,7 +69,7 @@
                         <a href="https://vaccinefinder.org" target="_blank">
                             <img
                                 alt="VaccineFinder"
-                                class="inline h-3"
+                                class="inline h-3 mb-1"
                                 src="/assets/img/vaccinefinder_logo.png"
                             />
                         </a>


### PR DESCRIPTION
This PR comes out of https://github.com/CAVaccineInventory/vaccinatethestates/pull/146, where @dolliars suggested a small margin on the VaccineFinder logo in the footer. I'd love to use something like `items-center` but can't seem to get that to work, but this margin does!

Before:
<img width="271" alt="Screen Shot 2021-04-23 at 6 24 13 🌃" src="https://user-images.githubusercontent.com/2546/115942858-208fa580-a461-11eb-9ccd-9ab7826c4dea.png">

After:
<img width="259" alt="Screen Shot 2021-04-23 at 6 23 56 🌃" src="https://user-images.githubusercontent.com/2546/115942860-27b6b380-a461-11eb-8138-bdceaf9632e1.png">

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-147--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [ ] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### About Us
- [ ] Organizers show up and randomize on page load
