### PR TITLE
Render site cards only when needed

### DIFF
--- a/webpack/near-me.js
+++ b/webpack/near-me.js
@@ -1,6 +1,6 @@
 import mapboxgl from "mapbox-gl";
 
-import { debounce } from './utils/misc.js'
+import { debounce } from "./utils/misc.js";
 import mapMarker from "./templates/mapMarker.handlebars";
 import {
   toggleVisibility,
@@ -109,20 +109,20 @@ export const initMap = () => {
   map.on("sourcedata", onSourceData);
 
   // Reload cards on map movement
-  map.on("moveend", () => {
-    debounce(() => {
-      toggleCardVisibility();
-
-      // When a marker is selected, it is centered in the map,
-      // which raises the `moveend` event and we want to scroll
-      // to the card...
-      renderCardsFromMap();
-      // But subsequent map movements (other than marker selection)
-      // shouldn't scroll anything.
-      scrollToCard = false;
-    }, 100)();
-  });
+  map.on("moveend", debouncedMoveEnd);
 };
+
+const debouncedMoveEnd = debounce(() => {
+  toggleCardVisibility();
+
+  // When a marker is selected, it is centered in the map,
+  // which raises the `moveend` event and we want to scroll
+  // to the card...
+  renderCardsFromMap();
+  // But subsequent map movements (other than marker selection)
+  // shouldn't scroll anything.
+  scrollToCard = false;
+}, 100);
 
 const onSourceData = (e) => {
   if (e.sourceId === vialSourceId && e.isSourceLoaded) {


### PR DESCRIPTION
* Map movement is a lot smoother
* `moveend` handler ensures cards are drawn

Resolves #159 

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-161--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [ ] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [ ] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### About Us
- [ ] Organizers show up and randomize on page load
