### PR TITLE
Remove break-all from appt details

### DIFF
--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -8,8 +8,8 @@
             <a class="text-sm" href="{{addressLink}}" target="_blank">{{address}}</a>
         </div>
         {{#if action}}
-            <a class="rounded-full bg-green-600 self-start px-4 py-2 text-white hover:bg-green-700 whitespace-nowrap text-sm flex" 
-                    href="{{action.href}}" 
+            <a class="rounded-full bg-green-600 self-start px-4 py-2 text-white hover:bg-green-700 whitespace-nowrap text-sm flex"
+                    href="{{action.href}}"
                     {{#if action.isSite}}target="_blank"{{/if}}>
                 <img class="h-5 me-1" src="/assets/img/{{#if action.isSite}}link_white{{else}}phone_white{{/if}}.svg" />
                 <span>{{t action.label}}</span>
@@ -23,7 +23,7 @@
         {{#if appointmentDetails}}
             <div class="grid grid-cols-1 px-4 py-2">
                 <h5 class="font-bold mb-1">{{t "appointment_details"}}</h5>
-                <div class="text-sm break-all">
+                <div class="text-sm">
                     {{{appointmentDetails}}}
                 </div>
             </div>


### PR DESCRIPTION
Remove `break-all` class from appointment details.

Fixes #163 

Link to Deploy Preview: https://deploy-preview-165--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [X] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [X] Geolocation works
- [ ] Searching by zip works
- [X] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [X] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### About Us
- [ ] Organizers show up and randomize on page load
