### PR TITLE
set break-words to fix long urls

### DIFF
--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -23,7 +23,7 @@
         {{#if appointmentDetails}}
             <div class="grid grid-cols-1 px-4 py-2">
                 <h5 class="font-bold mb-1">{{t "appointment_details"}}</h5>
-                <div class="text-sm">
+                <div class="text-sm break-words">
                     {{{appointmentDetails}}}
                 </div>
             </div>


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
Fixes bug where links with very, very long URLs would overflow appt details. Tailwind's break-words notably sets the overflow-wrap property, not the deprecated word-break property.

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-173--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [ ] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### Embed
- [ ] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [ ] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [ ] Searching with search box in map works

#### About Us
- [ ] Organizers show up and randomize on page load
