### PR TITLE
Card CSS fixes

### DIFF
--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -21,7 +21,7 @@
             {{/if}}
 
             {{#if vaccinesKnown}}
-                <div class="flex flex-row text-sm">
+                <div class="flex flex-row flex-wrap text-sm">
                     <div class="flex flex-row items-center me-4 {{#if offersModerna}}opacity-100{{else}}opacity-50{{/if}}">
                         {{#if offersModerna}}
                             <img class="h-5" src="/assets/img/checkmark-outline.svg" />
@@ -59,7 +59,7 @@
                 </a>
             {{/if}}
             {{#if lastVerified}}
-                <span class="text-xs me-1">{{t "verified_at" lastVerified=lastVerified}}</span>
+                <span class="text-xs me-1 text-end">{{t "verified_at" lastVerified=lastVerified}}</span>
             {{/if}}
         </div>
     </div>


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
Fixed issues I found in card css that can occur at specific widths with specific text lengths. https://github.com/CAVaccineInventory/vaccinatethestates/pull/177 made it very prominent to me, so put together this patch to fix.

- Now vaccines list wraps to prevent overflow issues
- verified text sticks to the right 

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-180--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
