### PR TITLE
Don't try render cards at zoom level 6

### DIFF
--- a/webpack/near-me.js
+++ b/webpack/near-me.js
@@ -139,7 +139,7 @@ const onSourceData = (e) => {
 const toggleCardVisibility = () => {
   const cardsContainer = document.getElementById("cards_container");
   const zoomedOutContainer = document.getElementById("zoomed_out_view");
-  if (map.getZoom() < 6) {
+  if (map.getZoom() <= 6) {
     toggleVisibility(cardsContainer, false);
     toggleVisibility(zoomedOutContainer, true);
     return;


### PR DESCRIPTION
Resolves #182

At zoom level 6, VIAL high feature layer has not been visible. So when we
try to get the features of this layer, there is none, causing the "no
sites found" to show. This commit ensure that we don't show this card
when zoom level is at most 6 (inclusive) or smaller (more zoomed out).

<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-181--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [ ] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [ ] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [ ] Searching with search box in map works

#### About Us
- [ ] Organizers show up and randomize on page load
