### PR TITLE
Fix issue with renderCardsFromMap not loading any data

### DIFF
--- a/webpack/near-me.js
+++ b/webpack/near-me.js
@@ -153,15 +153,14 @@ const renderCardsFromMap = () => {
   const noSites = document.getElementById("js-no-sites-alert");
 
   if (!map.isSourceLoaded(vialSourceId)) {
-    console.log("not loaded");
-    // For reasons unknown, we will hit this function when the map is not loaded, even though we await the source data loading
-    // prior to calling it. Manual testing tells us that the loaded flag gets toggled to false sometimes on zoom,
+    // For reasons unknown, we will hit this function when the source is not loaded, even though we await the source data loading
+    // prior to calling it. Manual testing tells us that the loaded flag gets toggled to false on movement,
     // and unfortunately there is no known callback to hook into to safely get this. To workaround this problem,
     // we simply try again, and again, if the map is not loaded.
     if (renderCardsTimeoutId) {
       clearTimeout(renderCardsTimeoutId);
     }
-    renderCardsTimeoutId = setTimeout(renderCardsFromMap, 50);
+    renderCardsTimeoutId = setTimeout(renderCardsFromMap, 100);
     return;
   }
 


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
Addresses https://github.com/CAVaccineInventory/vaccinatethestates/issues/183, and the broader loading issue in general. 183 just makes the issue very obvious because there is no slow zoom to the location, and thus the race condition is significantly more likely to occur.


We've tried numerous times to fix this problem, but have failed repeatedly. I am finally going to deal with this problem via the large blunt hammer of setTimeout.

To try and recap: 

- `map.queryRenderedFeatures`  would return an empty list even though there are clearly sites visible on the map. 
- We've tried a few things like adding a debouncer to the moveend callback and restricting when we call the render function
- These mostly worked, but not really. The root issue I found after testing is that zooming can set `map.loaded()` to false, and if it is false, `map.queryRenderedFeatures` returns nothing!
- There is no real callback one can hook into to resolve this problem. I tried numerous random ideas I found on stack overflow.

So instead, I just set a timeout at the beginning of rendering cards that is dependent on the map loading. This works perfectly in my testing, and i'd rather get something working out than something perfect.


<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-184--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

The easiest way to test this PR is to repeatedly hit https://deploy-preview-184--vaccinatethestates.netlify.app/embed?lat=37.8321173&lng=-122.2625529&zoom=12, and see that it loads cards,

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
