### PR TITLE
Switch to basic mapbox style with smaller circles zoomed out

### DIFF
--- a/webpack/near-me.js
+++ b/webpack/near-me.js
@@ -31,7 +31,7 @@ export const initMap = () => {
   mapboxgl.accessToken = mapboxToken;
   window.map = new mapboxgl.Map({
     container: "map",
-    style: "mapbox://styles/mapbox/streets-v11",
+    style: "mapbox://styles/calltheshots/cko9bo2ex5x6x17unjidv9a7j",
     center: [-98, 40], // starting position [lng, lat]
     zoom: 3, // starting zoom
   });
@@ -99,7 +99,7 @@ export const initMap = () => {
       "source": vialSourceId,
       "source-layer": "vialLow",
       "paint": {
-        "circle-radius": 4,
+        "circle-radius": 3,
         "circle-color": "#059669",
         "circle-stroke-width": 1,
         "circle-stroke-color": "#fff",


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-188--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
