### PR TITLE
Embed geolocator

### DIFF
--- a/webpack/embed-geolocator.js
+++ b/webpack/embed-geolocator.js
@@ -1,0 +1,40 @@
+import { t } from "./i18n.js";
+import { getCurrentPosition } from "./utils/geolocation.js";
+import embedGeolocatorTemplate from "./templates/embedGeolocator.handlebars";
+
+// Implements the mapbox control interface
+export class EmbedGeolocator {
+  constructor(callback) {
+    this.container = null;
+    this.callback = callback;
+  }
+  onAdd() {
+    const range = document
+      .createRange()
+      .createContextualFragment(embedGeolocatorTemplate());
+    const button = range.querySelector(".js-geolocator");
+
+    button.addEventListener("click", (e) => {
+      e.preventDefault;
+      button.textContent = t("getting_location");
+      button.blur();
+      getCurrentPosition(
+        (lat, lng) => {
+          button.textContent = t("locations_near_me");
+          this.callback(lat, lng);
+        },
+        () => {
+          button.textContent = t("locations_near_me");
+          alert(t("alert_detect"));
+        }
+      );
+    });
+
+    this.container = range;
+    return this.container;
+  }
+
+  onRemove() {
+    this.container.parentNode.removeChild(this.container);
+  }
+}

--- a/webpack/embed.js
+++ b/webpack/embed.js
@@ -14,8 +14,8 @@ const load = () => {
   initMap();
   initSearch(
     {
-      locCallback: (lat, lng, zoom, _) => {
-        moveMap(lat, lng, zoom, false);
+      locCallback: (lat, lng, zoom, source) => {
+        moveMap(lat, lng, zoom, source === "locate");
       },
     },
     {

--- a/webpack/search.js
+++ b/webpack/search.js
@@ -2,10 +2,10 @@ import * as Sentry from "@sentry/browser";
 import mapboxgl from "mapbox-gl";
 
 import { t } from "./i18n.js";
+import { EmbedGeolocator } from "./embed-geolocator.js";
 import { toggleVisibility } from "./utils/dom.js";
 import { mapboxToken } from "./utils/constants.js";
-
-import mapGeolocatorTemplate from "./templates/mapGeolocator.handlebars";
+import { getCurrentPosition } from "./utils/geolocation.js";
 
 const SEARCH_ZOOM_LEVEL = 12;
 let usingLocation = false;
@@ -36,7 +36,12 @@ export const initSearch = (cb, options) => {
     initStandaloneGeocoder(geocoder);
   } else if (options.type === "map") {
     window.map.addControl(geocoder, "top-left");
-    window.map.addControl(new MapGeolocator(), "top-right");
+    window.map.addControl(
+      new EmbedGeolocator((lat, lng) => {
+        submitLocation(lat, lng, SEARCH_ZOOM_LEVEL, "locate");
+      }),
+      "top-right"
+    );
   }
 
   if (options.parseQueryParams) {
@@ -46,27 +51,6 @@ export const initSearch = (cb, options) => {
     });
   }
 };
-
-class MapGeolocator {
-  constructor() {
-    this.container = null;
-  }
-  onAdd(map) {
-    const range = document.createRange().createContextualFragment(mapGeolocatorTemplate());
-    const button = range.querySelector('.js-geolocator');
-    button.addEventListener('click',(e) => {
-      e.preventDefault;
-      console.log("click");
-      button.blur();
-    })
-    this.container = range;
-    return this.container;;
-  }
-
-  onRemove() {
-    this.container.parentNode.removeChild(this.container);
-  }
-}
 
 const initMapboxGeocoder = () => {
   // TODO: import MapboxGeocoder via npm module instead of adding it as a script tag in head
@@ -132,16 +116,11 @@ const initStandaloneGeocoder = (geocoder) => {
 
 const handleGeoSearch = () => {
   const geolocationSubmit = document.getElementById("js-submit-geolocation");
-  navigator.geolocation.getCurrentPosition(
-    (position) => {
+  getCurrentPosition(
+    (lat, lng) => {
       usingLocation = false;
       toggleVisibility(geolocationSubmit, false);
-      submitLocation(
-        position.coords.latitude,
-        position.coords.longitude,
-        SEARCH_ZOOM_LEVEL,
-        "locate"
-      );
+      submitLocation(lat, lng, SEARCH_ZOOM_LEVEL, "locate");
     },
     (err) => {
       usingLocation = false;
@@ -151,10 +130,6 @@ const handleGeoSearch = () => {
         Sentry.captureException(new Error("Could not geolocate user"));
         alert(t("alert_detect"));
       }
-    },
-    {
-      maximumAge: 1000 * 60 * 5, // 5 minutes
-      timeout: 1000 * 15, // 15 seconds
     }
   );
 };

--- a/webpack/templates/embedGeolocator.handlebars
+++ b/webpack/templates/embedGeolocator.handlebars
@@ -1,0 +1,3 @@
+<button class="mapboxgl-ctrl js-geolocator text-md rounded-full bg-green-600 text-white hover:bg-green-700 px-4 py-2">
+    {{t "locations_near_me"}}
+</button>

--- a/webpack/templates/mapGeolocator.handlebars
+++ b/webpack/templates/mapGeolocator.handlebars
@@ -1,3 +1,0 @@
-<button class="mapboxgl-ctrl js-geolocator rounded-full bg-green-600 text-white hover:bg-green-700 px-4 py-2">
-    {{t "locations_near_me"}}
-</button>

--- a/webpack/utils/geolocation.js
+++ b/webpack/utils/geolocation.js
@@ -1,0 +1,14 @@
+export const getCurrentPosition = (onSuccess, onError) => {
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      onSuccess(position.coords.latitude, position.coords.longitude);
+    },
+    (err) => {
+      onError(err);
+    },
+    {
+      maximumAge: 1000 * 60 * 5, // 5 minutes
+      timeout: 1000 * 15, // 15 seconds
+    }
+  );
+};


### PR DESCRIPTION
This adds a geolocator to the `/embed` page to find locations near you. It is visually styled like the vaccinateca geolocator, but positioned differently because of rules about mapbox. I also made it so the button text updates during search to indicate work being done.

Minor refactoring of search code to share geolocation logic.

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->

Link to Deploy Preview: https://deploy-preview-190--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
