### PR TITLE
apply size transforms to search in embed

### DIFF
--- a/postcss/main.css
+++ b/postcss/main.css
@@ -39,7 +39,8 @@ a.no-underline {
 }
 
 /* search. Overrule predefined search stylings when appropriate TODO: fully write our own css without importing theirs */
-#search-container, .mapboxgl-ctrl-top-left .mapboxgl-ctrl-geocoder {
+#search-container,
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl-geocoder {
   transform: scale(
     0.7
   ); /* unfortunate hacks to undo their mediaquery styling */
@@ -50,7 +51,8 @@ a.no-underline {
 }
 
 @media (min-width: 640px) {
-  #search-container, .mapboxgl-ctrl-top-left .mapboxgl-ctrl-geocoder {
+  #search-container,
+  .mapboxgl-ctrl-top-left .mapboxgl-ctrl-geocoder {
     transform: scale(1);
   }
 }


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
I noticed while playing with the embed, that the search container gets realllllly big on small screens. This is fine on it's own, but it looks pretty bad next to the geolocate button. This is because the wild transforms I applied to search in the navbar didn't apply to search in the geocoder. Fixed with more css
<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-194--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
