### PR TITLE
add alt text and titles where appropriate to site cards

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -89,10 +89,10 @@ jj: J & J
 copied_to_clipboard: Copied to Clipboard
 locations_near_me: Locations near me
 copy_link: Copy link
+copy_link_alt: Copy link to location information
 moderna_available: Moderna available
 moderna_unavailable: Moderna unavailable
 pfizer_available: Pfizer available
 pfizer_unavailable: Pfizer unavailable
 jj_available: J&J available
 jj_unavailable: J&J unavailable
-phone_number: Phone Number

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ order: 1
         </div>
 
         <div id="cards_container" class="hidden animate-fade-in-down">
-          <div class="text-2xl font-semibold mb-4 mt-4 lg:mt-0">{% t home_title %}</div>
+          <h2 class="text-2xl font-semibold mb-4 mt-4 lg:mt-0">{% t home_title %}</h2>
           <div id="js-no-sites-alert" class="hidden bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded">{% t no_sites %}</div>
           <ol id="cards" class="space-y-4"></ol>
           <div class="my-4 flex flex-col items-center text-center">

--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -3,7 +3,7 @@
     <div class="flex flex-row justify-between px-4 pt-4 pb-2">
         <div class="me-2 flex-1">
             <div class="inline">
-                <button title="{{t "copy_link" }}"" alt="{{t "copy_link" }}" class="copy-button js-copy-button relative top-1" data-clipboard-text={{shareUrl}}>
+                <button title="{{t "copy_link_alt" }}"" alt="{{t "copy_link_alt" }}" class="copy-button js-copy-button relative top-1" data-clipboard-text={{shareUrl}}>
                     <img class="copy-button__img h-5" src="/assets/img/link.svg" />
                     <img class="copy-button__img-hover h-5 hidden" src="/assets/img/link_green.svg" />
                 </button>
@@ -28,27 +28,36 @@
 
             {{#if vaccinesKnown}}
                 <div class="flex flex-row flex-wrap text-sm">
-                    <div class="flex flex-row items-center me-4 {{#if offersModerna}}opacity-100{{else}}opacity-50{{/if}}">
+                    <div 
+                        role="img" 
+                        aria-label="{{#if offersModerna}}{{t "moderna_available"}}{{else}}{{t "moderna_unavailable"}}{{/if}}" 
+                        class="flex flex-row items-center me-4 {{#if offersModerna}}opacity-100{{else}}opacity-50{{/if}}">
                         {{#if offersModerna}}
-                            <img alt="{{t "moderna_available"}}" class="h-5" src="/assets/img/checkmark-outline.svg" />
+                            <img class="h-5" src="/assets/img/checkmark-outline.svg" />
                         {{else}}
-                            <img alt="{{t "moderna_unavailable"}}" class="h-5" src="/assets/img/close-outline.svg" />
+                            <img class="h-5" src="/assets/img/close-outline.svg" />
                         {{/if}}
                         <span>{{t "moderna" }}</span>
                     </div>
-                    <div class="flex flex-row items-center me-4 {{#if offersPfizer}}opacity-100{{else}}opacity-50{{/if}}">
+                    <div 
+                        role="img"
+                        aria-label="{{#if offersPfizer}}{{t "pfizer_available"}}{{else}}{{t "pfizer_unavailable"}}{{/if}}" 
+                        class="flex flex-row items-center me-4 {{#if offersPfizer}}opacity-100{{else}}opacity-50{{/if}}">
                         {{#if offersPfizer}}
-                            <img alt="{{t "pfizer_available"}}" class="h-5" src="/assets/img/checkmark-outline.svg" />
+                            <img class="h-5" src="/assets/img/checkmark-outline.svg" />
                         {{else}}
-                            <img alt="{{t "pfizer_unavailable"}}" class="h-5" src="/assets/img/close-outline.svg" />
+                            <img class="h-5" src="/assets/img/close-outline.svg" />
                         {{/if}}
                         <span>{{t "pfizer" }}</span>
                     </div>
-                    <div class="flex flex-row items-center {{#if offersJJ}}opacity-100{{else}}opacity-50{{/if}}">
+                    <div 
+                        role="img"
+                        aria-label="{{#if offersJJ}}{{t "jj_available"}}{{else}}{{t "jj_unavailable"}}{{/if}}" 
+                        class="flex flex-row items-center {{#if offersJJ}}opacity-100{{else}}opacity-50{{/if}}">
                         {{#if offersJJ}}
-                            <img alt="{{t "jj_available"}}" class="h-5" src="/assets/img/checkmark-outline.svg" />
+                            <img class="h-5" src="/assets/img/checkmark-outline.svg" />
                         {{else}}
-                            <img alt="{{t "jj_unavailable"}}" class="h-5" src="/assets/img/close-outline.svg" />
+                            <img class="h-5" src="/assets/img/close-outline.svg" />
                         {{/if}}
                         <span>{{t "jj" }}</span>
                     </div>
@@ -60,7 +69,7 @@
                 <a class="self-end rounded-full bg-green-600 px-4 py-2 mb-2 text-white hover:bg-green-700 whitespace-nowrap text-sm flex"
                         href="{{action.href}}"
                         {{#if action.isSite}}target="_blank"{{/if}}>
-                    <img class="h-5 me-1" src="/assets/img/{{#if action.isSite}}link_white{{else}}phone_white{{/if}}.svg" />
+                    <img aria-hidden="true" class="h-5 me-1" src="/assets/img/{{#if action.isSite}}link_white{{else}}phone_white{{/if}}.svg" />
                     <span>{{t action.label}}</span>
                 </a>
             {{/if}}
@@ -101,13 +110,13 @@
                 <div class="flex flex-row flex-wrap justify-between text-sm">
                     {{#if website}}
                         <div class="flex flex-row">
-                            <img alt="{{t "website"}}" class="h-5 mb-1 me-2" src="/assets/img/link.svg" />
+                            <img aria-hidden="true" class="h-5 mb-1 me-2" src="/assets/img/link.svg" />
                             <a href="{{website}}" class="break-all" target="_blank">{{website}}</a>
                         </div>
                     {{/if}}
                     {{#if phoneNumber}}
                         <div class="flex flex-row">
-                        <img alt="{{t "phone_number"}}" class="h-5 me-2" src="/assets/img/phone.svg" />
+                        <img aria-hidden="true" class="h-5 me-2" src="/assets/img/phone.svg" />
                             <a href="tel:{{phoneNumber}}">{{phoneNumber}}</a>
                         </div>
                     {{/if}}


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
First stab at https://github.com/CAVaccineInventory/vaccinatethestates/issues/192, adding alt text and titles to site cards. Still no aria labels, but this is a good starting point
<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-195--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
