### PR TITLE
npm audit fix to postcss vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3828,9 +3828,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4151,16 +4151,20 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+      "version": "8.2.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
       "dependencies": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
+        "nanoid": "^3.1.23",
         "source-map": "^0.6.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-cli": {
@@ -8714,9 +8718,9 @@
       "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
     },
     "nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -8957,12 +8961,12 @@
       }
     },
     "postcss": {
-      "version": "8.2.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+      "version": "8.2.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
       "requires": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
+        "nanoid": "^3.1.23",
         "source-map": "^0.6.1"
       }
     },


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
dependabot was warning us about our postcss version. `npm audit fix` to upgrade the locked postcss version to a safe one.
<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-206--vaccinatethestates.netlify.app/
