### PR TITLE
[tech debt] move page specific js to it's own page directory

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,9 +11,9 @@ if (process.env.NETLIFY) {
 module.exports = {
   "entry": {
     "main": "./webpack/main.js",
-    "index": "./webpack/index.js",
-    "about-us": "./webpack/about-us.js",
-    "embed": "./webpack/embed.js",
+    "index": "./webpack/pages/index.js",
+    "about-us": "./webpack/pages/about-us.js",
+    "embed": "./webpack/pages/embed.js",
   },
   "output": {
     "path": path.resolve(__dirname, "assets/js"),

--- a/webpack/pages/about-us.js
+++ b/webpack/pages/about-us.js
@@ -1,4 +1,4 @@
-import { initSearch } from "./search.js";
+import { initSearch } from "../search.js";
 
 window.addEventListener("load", () => {
   initSearch(

--- a/webpack/pages/embed.js
+++ b/webpack/pages/embed.js
@@ -1,6 +1,6 @@
-import { initSearch } from "./search.js";
-import { initMap, moveMap } from "./near-me.js";
-import { toggleVisibility } from "./utils/dom.js";
+import { initSearch } from "../search.js";
+import { initMap, moveMap } from "../near-me.js";
+import { toggleVisibility } from "../utils/dom.js";
 
 window.addEventListener("load", () => load());
 

--- a/webpack/pages/index.js
+++ b/webpack/pages/index.js
@@ -1,6 +1,6 @@
-import { initSearch } from "./search.js";
-import { initMap, moveMap } from "./near-me.js";
-import pfizerLinkTemplate from "./templates/pfizerLink.handlebars";
+import { initSearch } from "../search.js";
+import { initMap, moveMap } from "../near-me.js";
+import pfizerLinkTemplate from "../templates/pfizerLink.handlebars";
 
 window.addEventListener("load", () => load());
 


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
Addresses https://github.com/CAVaccineInventory/vaccinatethestates/issues/112, just small tech debt to separate page JS into its own folder. That way it's easier to know to not cross-import these files and accidentally trigger the page onload handlers.
<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-209--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
