### PR TITLE
[tech debt] abstract vaccine type to inline partial

### DIFF
--- a/webpack/templates/siteCard.handlebars
+++ b/webpack/templates/siteCard.handlebars
@@ -1,3 +1,14 @@
+{{#*inline "offersVaccine"}}
+    <div class="flex flex-row items-center {{#unless last}}me-4{{/unless}} {{#if offersVaccine}}opacity-100{{else}}opacity-50{{/if}}">
+        {{#if offersVaccine}}
+            <img class="h-5" src="/assets/img/checkmark-outline.svg" />
+        {{else}}
+            <img class="h-5" src="/assets/img/close-outline.svg" />
+        {{/if}}
+        <span>{{name}}</span>
+    </div>
+{{/inline}}
+
 <li id="{{id}}" class="site-card rounded-lg relative grid grid-cols-1
      shadow border bg-white">
     <div class="flex flex-row justify-between px-4 pt-4">
@@ -40,7 +51,7 @@
         {{#if availabilityKnown}}
             <div class="flex flex-row text-xs {{#if vaccinesKnown}}mb-2{{/if}}">
                 {{#if walkins}}
-                <span class="rounded-full bg-gray-200 px-2 py-1 text-black whitespace-nowrap flex me-2">{{t "walkin" }}</span>
+                    <span class="rounded-full bg-gray-200 px-2 py-1 text-black whitespace-nowrap flex me-2">{{t "walkin" }}</span>
                 {{/if}}
                 {{#if appointments}}
                     <span class="rounded-full bg-gray-200 px-2 py-1 text-black whitespace-nowrap flex">{{t "appointments_available" }}</span>
@@ -50,30 +61,9 @@
 
         {{#if vaccinesKnown}}
             <div class="flex flex-row flex-wrap text-sm">
-                <div class="flex flex-row items-center me-4 {{#if offersModerna}}opacity-100{{else}}opacity-50{{/if}}">
-                    {{#if offersModerna}}
-                        <img class="h-5" src="/assets/img/checkmark-outline.svg" />
-                    {{else}}
-                        <img class="h-5" src="/assets/img/close-outline.svg" />
-                    {{/if}}
-                    <span>{{t "moderna" }}</span>
-                </div>
-                <div class="flex flex-row items-center me-4 {{#if offersPfizer}}opacity-100{{else}}opacity-50{{/if}}">
-                    {{#if offersPfizer}}
-                        <img class="h-5" src="/assets/img/checkmark-outline.svg" />
-                    {{else}}
-                        <img class="h-5" src="/assets/img/close-outline.svg" />
-                    {{/if}}
-                    <span>{{t "pfizer" }}</span>
-                </div>
-                <div class="flex flex-row items-center {{#if offersJJ}}opacity-100{{else}}opacity-50{{/if}}">
-                    {{#if offersJJ}}
-                        <img class="h-5" src="/assets/img/checkmark-outline.svg" />
-                    {{else}}
-                        <img class="h-5" src="/assets/img/close-outline.svg" />
-                    {{/if}}
-                    <span>{{t "jj" }}</span>
-                </div>
+                {{> offersVaccine offersVaccine=offersModerna name=(t "moderna")}}
+                {{> offersVaccine offersVaccine=offersPfizer name=(t "pfizer")}}
+                {{> offersVaccine offersVaccine=offersJJ name=(t "jj") last=true}}
             </div>
         {{/if}}
     </div>


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->
I've gotten weirdly good at handlebars templating recently due to work on Velma, and I've realized we can cleanup our site template a bit with some use of handlebars partials
<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-210--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
