### PR TITLE
minor style cleanup for map popup

### DIFF
--- a/webpack/templates/mapMarker.handlebars
+++ b/webpack/templates/mapMarker.handlebars
@@ -1,17 +1,14 @@
-<div class="mx-1">
+<div class="mx-2">
   <h1 class="text-lg text-green-600">
     {{name}}
   </h1>
 
-  <div>
+  <div class="flex flex-col text-sm mt-2">
     {{#if address}}
-        <a class="text-sm pt-2" href="{{addressLink}}" target="_blank">{{address}}</a>
-        {{#if website}}
-            &middot;
-        {{/if}}
+        <a class="my-1" href="{{addressLink}}" target="_blank">{{address}}</a>
     {{/if}}
     {{#if website}}
-        <a class="text-sm" href={{website}} target="_blank">{{ t "website" }}</span>
+        <a class="my-1" href={{website}} target="_blank">{{ t "website" }}</span>
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
<!--
    Replace this comment with a description of the change(s) being made.
    Screenshots are especially useful if you want to show how the site is changing.
    If relevant, try to reference Issue IDs that this PR resolves.
-->

<!--
    Replace the NNN in the URL below with the ID of this Pull Request.
    That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-NNN--vaccinatethestates.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [ ] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [ ] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### Embed
- [ ] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [ ] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [ ] Searching with search box in map works

#### About Us
- [ ] Organizers show up and randomize on page load
