### PR TITLE
Remove Pfizer text from blank slate

### DIFF
--- a/webpack/filters.js
+++ b/webpack/filters.js
@@ -1,5 +1,4 @@
 import { toggleVisibility } from "./utils/dom.js";
-import pfizerLinkTemplate from "./templates/pfizerLink.handlebars";
 
 /**
  * filters.js sets up the filter button at the top of the page and parses
@@ -23,7 +22,6 @@ const initFilters = (callback) => {
   const cb = () => {
     toggleActiveIcon();
     callback(createMapboxFilter());
-    setupPfizerLink(cb);
   };
 
   const urlParams = new URLSearchParams(window.location.search);
@@ -76,7 +74,6 @@ const initFilters = (callback) => {
   });
 
   toggleActiveIcon();
-  setupPfizerLink(cb);
 };
 
 const getFilterQueryParams = () => {
@@ -119,42 +116,6 @@ const createMapboxFilter = () => {
     }
   }
   return filter;
-};
-
-const setupPfizerLink = (callback) => {
-  const pfizerNotice = document.querySelector(".js-pfizer");
-  if (pfizerNotice) {
-    pfizerNotice.innerHTML = "";
-    const pfizerTemplate = pfizerLinkTemplate({
-      pfizerFiltered:
-        filterPfizer && !filterJJ && !filterModerna && !filterUnknown,
-    });
-    const range = document
-      .createRange()
-      .createContextualFragment(pfizerTemplate);
-
-    range.querySelector("a").addEventListener("click", (e) => {
-      e.preventDefault();
-
-      if (filterPfizer && !filterJJ && !filterModerna && !filterUnknown) {
-        filterPfizer = false;
-      } else {
-        filterPfizer = true;
-        filterJJ = false;
-        filterModerna = false;
-        filterUnknown = false;
-      }
-
-      modernaInput.checked = filterModerna;
-      pfizerInput.checked = filterPfizer;
-      jjInput.checked = filterJJ;
-      unknownInput.checked = filterUnknown;
-
-      callback();
-    });
-
-    pfizerNotice.appendChild(range);
-  }
 };
 
 const toggleActiveIcon = () => {

--- a/webpack/templates/pfizerLink.handlebars
+++ b/webpack/templates/pfizerLink.handlebars
@@ -1,7 +1,0 @@
-<div class="pt-2 mt-2 border-t text-sm">
-    {{#if pfizerFiltered }}
-        The Pfizer-BioNTech vaccine has been authorized for children as young as 12. This map shows only sites with Pfizer-BioNTech doses reported available. <a href="/">Show all vaccination sites.</a>
-    {{else}}
-        The Pfizer-BioNTech vaccine has been authorized for children as young as 12. <a href="/?pfizer=1">Show only sites with Pfizer-BioNTech doses reported available.</a>
-    {{/if}}
-</div>


### PR DESCRIPTION
Resolves #234.
Link to Deploy Preview: https://deploy-preview-236--vaccinatethestates.netlify.app/
<img width="1422" alt="Screen Shot 2021-05-26 at 08 24 03" src="https://user-images.githubusercontent.com/531003/119687649-3a276280-bdfc-11eb-9b86-b1ec32f90cbc.png">

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [x] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [x] Geolocation works
- [x] Searching by zip works
- [x] Cards show useful information
  - [x] Cards address links to Google Maps
  - [x] Cards can be expanded
- [x] Zooming out gets us back to blank slate text

#### Embed
- [x] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [x] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [x] Searching with search box in map works

#### About Us
- [x] Organizers show up and randomize on page load
