### PR TITLE
Shutdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ order: 1
 ---
 <link href="assets/css/near-me.css" rel="stylesheet" />
 <div class="flex flex-col items-center">
-  <div class="container mx-auto mt-4 lg:mt-8">
-    <div class="results flex flex-col-reverse lg:grid lg:grid-cols-5">
+  <div class="container mx-auto mt-4 lg:mt-8 ">
+    <div class="results flex flex-col-reverse lg:grid lg:grid-cols-2">
       <div id="main" class="flex flex-col lg:col-span-2">
 
         <div id="zoomed_out_view" class="animate-fade-in-up flex-col items-center lg:col-span-2">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,11 @@ order: 1
           <div> {% t home_body %} </div>
           <div class="js-pfizer"></div>
         </div>
+        <a class="self-end rounded-full bg-green-600 px-4 py-2 mb-2 text-white hover:bg-green-700 whitespace-nowrap text-sm flex" href="https://vaccines.gov" target="_blank">
+          <img class="h-5 me-1" src="/assets/img/link_white.svg">
+          <span>Visit Vaccines.gov</span>
+        
+        </a>
 
       </div>
 

--- a/index.html
+++ b/index.html
@@ -16,17 +16,9 @@ order: 1
           <div class="js-pfizer"></div>
         </div>
 
-        <div id="cards_container" class="hidden animate-fade-in-down">
-          <div class="text-2xl font-semibold mb-4 mt-4 lg:mt-0">{% t home_title %}</div>
-          <div id="js-no-sites-alert" class="hidden bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 mb-4 rounded">{% t no_sites %}</div>
-          <ol id="cards" class="space-y-4"></ol>
-          <div class="my-4 flex flex-col items-center text-center">
-            <a href="https://airtable.com/shriM4cld0UfVf2ud?prefill_What+correction+are+you+reporting%3F=Add%20a%20missing%20hospital%2Fpharmacy" class="text-black" target="_blank">{% t report_missing %}</a>
-          </div>
-        </div>
       </div>
 
-      <div id="map" class="home-map h-72 bg-gray-200 lg:ms-8 lg:col-span-3"></div>
+
 
     </div>
   </div>


### PR DESCRIPTION
This PR removes the map and replaces it with a shutdown message to tell people that the project is over

This still needs internationalized content and some styling changes such as: 
- [ ] force the footer to be at the bottom (or remove it)
- [ ] move the button  so it is centered below the content

Link to Deploy Preview: https://deploy-preview-333--vaccinatethestates.netlify.app/

Screenshot so-far
![unknown](https://user-images.githubusercontent.com/17362949/126414200-af06ab29-4626-4fef-aa99-4c24938242bd.png)


---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [ ] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [ ] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### Embed
- [ ] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [ ] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [ ] Searching with search box in map works

#### About Us
- [ ] Organizers show up and randomize on page load
