### PR TITLE
Shutdown banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,9 @@ order: 1
     <div class="alert-danger">
       <div class="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
         <div class="flex flex-col md:flex-row items-center">
-          <span class="hidden sm:flex p-2 rounded-lg ">
+          <span class="flex p-2 rounded-lg ">
             <!-- Heroicon name: outline/speakerphone -->
-            <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <svg class="h-6 w-6 hidden md:block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
             </svg>
           </span>

--- a/index.html
+++ b/index.html
@@ -20,37 +20,26 @@ order: 1
     <!-- This example requires Tailwind CSS v2.0+ -->
     <div class="alert-danger">
       <div class="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
-        <div class="flex ">
-          <div class="w-0 flex-1 flex items-center">
-            <span class="flex p-2 rounded-lg ">
-              <!-- Heroicon name: outline/speakerphone -->
-              <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-              </svg>
+        <div class="flex items-center">
+          <span class="flex p-2 rounded-lg ">
+            <!-- Heroicon name: outline/speakerphone -->
+            <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+            </svg>
+          </span>
+          <p class="ml-3 font-medium  flex-1  ">
+            <span class="">
+              We announced a new product!
             </span>
-            <p class="ml-3 font-medium  truncate">
-              <span class="">
-                We announced a new product!
-              </span>
-              <span class="md:inline">
-                Big news! We're excited to announce a brand new product.
-              </span>
-            </p>
-          </div>
-          <div class="order-3 mt-2  sm:order-2 sm:mt-0 sm:w-auto">
+            <span class="md:inline">
+              Big news! We're excited to announce a brand new product.
+            </span>
+          </p>
+          <div class="order-3 sm:order-2 sm:w-auto">
             <a href="#" class="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600  hover:bg-indigo-50">
               Learn more
             </a>
           </div>
-          <!-- <div class="order-2 sm:order-3 sm:ml-3">
-            <button type="button" class="-mr-1 flex p-2 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-white sm:-mr-2">
-              <span class="sr-only">Dismiss</span>
-              <!-- Heroicon name: outline/x --
-              <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div> -->
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -20,14 +20,14 @@ order: 1
     <!-- This example requires Tailwind CSS v2.0+ -->
     <div class="alert-danger">
       <div class="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
-        <div class="flex items-center">
-          <span class="flex p-2 rounded-lg ">
+        <div class="flex flex-col md:flex-row items-center">
+          <span class="hidden sm:flex p-2 rounded-lg ">
             <!-- Heroicon name: outline/speakerphone -->
             <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
             </svg>
           </span>
-          <p class="ml-3 font-medium  flex-1  ">
+          <p class="ml-3 font-medium text-center md:text-left flex-1">
             <span class="">
               We announced a new product!
             </span>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,56 @@ title: home_title
 add_to_nav: false
 order: 1
 ---
+<style>
+  .alert-danger {
+    color: #842029;
+    background-color: #f8d7da;
+    border-color: #f5c2c7;
+    margin:5px;
+    border-radius: 20px;
+    border: 1px solid;
+}
+</style>
 <link href="assets/css/near-me.css" rel="stylesheet" />
 <div class="flex flex-col items-center">
   <div class="container mx-auto mt-4 lg:mt-8">
+    <!-- This example requires Tailwind CSS v2.0+ -->
+    <div class="alert-danger">
+      <div class="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
+        <div class="flex ">
+          <div class="w-0 flex-1 flex items-center">
+            <span class="flex p-2 rounded-lg ">
+              <!-- Heroicon name: outline/speakerphone -->
+              <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+              </svg>
+            </span>
+            <p class="ml-3 font-medium  truncate">
+              <span class="">
+                We announced a new product!
+              </span>
+              <span class="md:inline">
+                Big news! We're excited to announce a brand new product.
+              </span>
+            </p>
+          </div>
+          <div class="order-3 mt-2  sm:order-2 sm:mt-0 sm:w-auto">
+            <a href="#" class="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600  hover:bg-indigo-50">
+              Learn more
+            </a>
+          </div>
+          <!-- <div class="order-2 sm:order-3 sm:ml-3">
+            <button type="button" class="-mr-1 flex p-2 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-white sm:-mr-2">
+              <span class="sr-only">Dismiss</span>
+              <!-- Heroicon name: outline/x --
+              <svg class="h-6 w-6 " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div> -->
+        </div>
+      </div>
+    </div>
     <div class="results flex flex-col-reverse lg:grid lg:grid-cols-5">
       <div id="main" class="flex flex-col lg:col-span-2">
 


### PR DESCRIPTION
Similar to #333 but adds a banner to discuss the shutdown instead of turning the whole page into an explaination of the shutdown.


Link to Deploy Preview: https://deploy-preview-337--vaccinatethestates.netlify.app/


Still missing internationalized content, otherwise should be good to go.

Screenshots:
![image](https://user-images.githubusercontent.com/17362949/126727717-56d1ef14-d05b-4a94-98ab-8c44c9e9d49d.png)
![Screenshot_20210722_182711](https://user-images.githubusercontent.com/17362949/126727750-9a004c1c-b0dd-4d31-878b-8c0e2cb52c3a.png)


---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

- [ ] I solemnly swear that I QA'd my change. My change does not break the site on `localhost` nor staging.

#### Home Page
- [ ] Geolocation works
- [ ] Searching by zip works
- [ ] Cards show useful information
  - [ ] Cards address links to Google Maps
  - [ ] Cards can be expanded
- [ ] Zooming out gets us back to blank slate text

#### Embed
- [ ] Query parameters for zip `?zip={zipcode}&zoom={zoom}`
- [ ] Query parameters for lat and lng works `?lat={lat}&lng={lng}&zoom={zoom}`
- [ ] Searching with search box in map works

#### About Us
- [ ] Organizers show up and randomize on page load
