### PR TITLE
Shutdown banner within embed 🖼

### DIFF
--- a/embed.html
+++ b/embed.html
@@ -8,9 +8,9 @@ add_to_nav: false
 <div>
   <div class="flex flex-col-reverse lg:grid lg:grid-cols-5">
     <div id="main" class="flex flex-col lg:col-span-2 p-4">
-      {% include shutdown.html %}
 
       <div id="zoomed_out_view" class="hidden animate-fade-in-up flex-col items-center lg:col-span-2">
+        {% include shutdown.html %}
         <div class="bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded">{% t embed_zoomed_out %}</div>
       </div>
 
@@ -18,6 +18,7 @@ add_to_nav: false
         <div class="flex justify-end mb-2">
           {% include filters.html %}
         </div>
+        {% include shutdown.html %}
         <ol id="cards" class="space-y-4"></ol>
       </div>
 

--- a/embed.html
+++ b/embed.html
@@ -8,6 +8,7 @@ add_to_nav: false
 <div>
   <div class="flex flex-col-reverse lg:grid lg:grid-cols-5">
     <div id="main" class="flex flex-col lg:col-span-2 p-4">
+      {% include shutdown.html %}
 
       <div id="zoomed_out_view" class="hidden animate-fade-in-up flex-col items-center lg:col-span-2">
         <div class="bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded">{% t embed_zoomed_out %}</div>


### PR DESCRIPTION
Link to Deploy Preview: https://deploy-preview-342--vaccinatethestates.netlify.app/

Begin displaying the shutdown notice on the embed.

The partial is included twice - once in the zoomed out view and once in the view with cards - in order to have clean formatting in both cases. As an unfortunate side effect, zooming causes the notice to jump (rather than slide).